### PR TITLE
chore: bump go version and open ports to local

### DIFF
--- a/Dockerfile.story-geth
+++ b/Dockerfile.story-geth
@@ -1,5 +1,5 @@
 # Build Geth in a stock Go builder container
-FROM golang:1.22.10-alpine as builder
+FROM golang:1.22.11-alpine as builder
 
 RUN apk add --no-cache gcc musl-dev linux-headers git
 

--- a/Dockerfile.story-node
+++ b/Dockerfile.story-node
@@ -1,5 +1,5 @@
 # Build Geth in a stock Go builder container
-FROM golang:1.22.10-alpine as builder
+FROM golang:1.22.11-alpine as builder
 
 # Set the Current Working Directory inside the container
 WORKDIR /story
@@ -19,6 +19,6 @@ FROM alpine:latest
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /story/story /usr/local/bin/
 
-EXPOSE 8545 8546 30303 30303/udp
+EXPOSE 1317 8545 8546 30303 30303/udp
 
 WORKDIR /root/.story/story

--- a/config/story/validator1/story/story.toml
+++ b/config/story/validator1/story/story.toml
@@ -63,7 +63,7 @@ evm-build-delay = "600ms"
 evm-build-optimistic = false
 
 # APIEnable defines if the API server should be enabled.
-api-enable = false
+api-enable = true
 
 # APIAddress defines the API server address to listen on.
 api-address = "0.0.0.0:1317"

--- a/docker-compose-validator1.yml
+++ b/docker-compose-validator1.yml
@@ -67,6 +67,8 @@ services:
     networks:
       story-localnet:
         ipv4_address: 10.0.0.20
+    ports:
+      - "8545:8545"
     depends_on:
       - validator1-geth-init
     <<: *logging
@@ -109,6 +111,9 @@ services:
     networks:
       story-localnet:
         ipv4_address: 10.0.0.21
+    ports:
+      - "1317:1317"
+      - "26657:26657"
     depends_on:
       - validator1-geth
       - validator1-node-init


### PR DESCRIPTION
Bump go version to v1.22.11 according to the latest upgrade in Story.
And open some ports to connect from local by default.