### PR TITLE
chore: rename log-level to log_level

### DIFF
--- a/docker-compose-bootnode1.yml
+++ b/docker-compose-bootnode1.yml
@@ -97,7 +97,7 @@ services:
       - --api-address=0.0.0.0:1317
       - --engine-jwt-file=/root/.story/geth/data/jwtsecret
       - --engine-endpoint=http://bootnode1-geth:8551
-      - --log-level=debug
+      - --log_level=debug
     volumes:
       - ./config/story/genesis-node.json:/root/.story/story/config/genesis.json
       - ./config/story/bootnode1/story/config.toml:/root/.story/story/config/config.toml

--- a/docker-compose-validator1.yml
+++ b/docker-compose-validator1.yml
@@ -99,7 +99,7 @@ services:
       - --api-address=0.0.0.0:1317
       - --engine-jwt-file=/root/.story/geth/data/jwtsecret
       - --engine-endpoint=http://validator1-geth:8551
-      - --log-level=debug
+      - --log_level=debug
     volumes:
       - ./config/story/genesis-node.json:/root/.story/story/config/genesis.json
       - ./config/story/validator1/story/config.toml:/root/.story/story/config/config.toml

--- a/docker-compose-validator2.yml
+++ b/docker-compose-validator2.yml
@@ -97,7 +97,7 @@ services:
       - --api-address=0.0.0.0:1317
       - --engine-jwt-file=/root/.story/geth/data/jwtsecret
       - --engine-endpoint=http://validator2-geth:8551
-      - --log-level=debug
+      - --log_level=debug
     volumes:
       - ./config/story/genesis-node.json:/root/.story/story/config/genesis.json
       - ./config/story/validator2/story/config.toml:/root/.story/story/config/config.toml

--- a/docker-compose-validator3.yml
+++ b/docker-compose-validator3.yml
@@ -97,7 +97,7 @@ services:
       - --api-address=0.0.0.0:1317
       - --engine-jwt-file=/root/.story/geth/data/jwtsecret
       - --engine-endpoint=http://validator3-geth:8551
-      - --log-level=debug
+      - --log_level=debug
     volumes:
       - ./config/story/genesis-node.json:/root/.story/story/config/genesis.json
       - ./config/story/validator3/story/config.toml:/root/.story/story/config/config.toml

--- a/docker-compose-validator4.yml
+++ b/docker-compose-validator4.yml
@@ -97,7 +97,7 @@ services:
       - --api-address=0.0.0.0:1317
       - --engine-jwt-file=/root/.story/geth/data/jwtsecret
       - --engine-endpoint=http://validator4-geth:8551
-      - --log-level=debug
+      - --log_level=debug
     volumes:
       - ./config/story/genesis-node.json:/root/.story/story/config/genesis.json
       - ./config/story/validator4/story/config.toml:/root/.story/story/config/config.toml

--- a/generate_docker_compose.sh
+++ b/generate_docker_compose.sh
@@ -110,7 +110,7 @@ services:
       - --api-address=0.0.0.0:1317
       - --engine-jwt-file=\/root/.story/geth/data/jwtsecret
       - --engine-endpoint=http://${NODE_NAME}-geth:8551
-      - --log-level=debug
+      - --log_level=debug
     volumes:
       - ./config/story/genesis-node.json:\/root/.story/story/config/genesis.json
       - ./config/story/${NODE_NAME}/story/config.toml:\/root/.story/story/config/config.toml


### PR DESCRIPTION
The flag of `log-level` is renamed to `log_level` in this [PR](https://github.com/piplabs/story/pull/482).
Accordingly, renamed all related flags.