### PR TITLE
config: set staking singularity_height to 10 in localnet genesis

### DIFF
--- a/config/story/genesis-node.json
+++ b/config/story/genesis-node.json
@@ -433,7 +433,7 @@
         "min_commission_rate": "0.050000000000000000",
         "min_delegation": "1024000000000",
         "flexible_period_type": 0,
-        "singularity_height": "600",
+        "singularity_height": "10",
         "periods": [
           {
             "period_type": 0,


### PR DESCRIPTION
Lower singularity_height in genesis-node.json so local development matches the intended early singularity behavior; only this field is changed.

Made-with: Cursor

## Description
<!--
Add a description of the changes that this PR introduces

Example:
This PR touches configurations, including:
1. Add a new parameter `max_stake` in staking config
2. Removes the parameter `min_slash` in slashing config
3. Modifies the parameter `min_vote` to `min_vote_weight` in governance config
-->

## Test Plan 
<!--
The test plan section indicates detailed steps on how to verify and test code changes. 
You can list the test cases or test steps that need to be performed.

Example:
1. Fuzz test `max_stake`
2. Modify test on governance config to test `min_vote_weight`
-->

## Related Issue
<!--
The related issue section can indicate with which issue or task this PR is related.

Example:
- Closes #123
- Tracks #321
-->

## Notes
<!--
The notes section can alert others of special requirements or information that need extra attention.

Example:
- Governance `min_vote_weight` is denoted in nano decimals.
- Staking economics recalculation is required.
-->
