### PR TITLE
infra: enforce binary-staging path with sha256 verify

### DIFF
--- a/scripts/stage_binary.sh
+++ b/scripts/stage_binary.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# stage_binary.sh — Stage a freshly-built story linux binary at the path
+# the docker-compose build context expects, and record a sha256 fingerprint
+# so start.sh can verify the running image actually contains this binary.
+#
+# Usage:
+#   ./scripts/stage_binary.sh <path-to-linux-arm64-or-amd64-story-binary>
+#
+# Example:
+#   ./scripts/stage_binary.sh ../story-private-fork/build/story-linux
+#   ./scripts/stage_binary.sh ../story/build/story-linux
+#
+# Why this exists:
+#   The docker-compose-*.yml `build.context` points to a sibling repo
+#   (e.g., ../story-private-fork). `Dockerfile.story-node` then runs
+#   `COPY story-prebuilt /usr/local/bin/story` — relative to the build
+#   context, NOT relative to story-localnet. Manually `cp`-ing to
+#   story-localnet/story-prebuilt is silently ignored by docker. This
+#   script derives the destination from docker-compose so it adapts to
+#   whichever sibling repo the context currently points to.
+
+set -euo pipefail
+
+SRC=${1:?usage: stage_binary.sh <path-to-linux-story-binary>}
+
+if [[ ! -f "$SRC" ]]; then
+    echo "ERROR: source binary not found at $SRC" >&2
+    exit 1
+fi
+
+LOCALNET_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+COMPOSE_FILE="$LOCALNET_DIR/docker-compose-bootnode1.yml"
+
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+    echo "ERROR: $COMPOSE_FILE not found — are you in story-localnet?" >&2
+    exit 1
+fi
+
+# Extract bootnode1-node service's build.context. AWK over the YAML treats
+# every top-level service block as a window; print the first `context:`
+# value inside the `bootnode1-node:` window.
+CTX=$(awk '
+    /^  bootnode1-node:/ { in_block=1; next }
+    in_block && /^  [a-zA-Z]/ { in_block=0 }
+    in_block && $1 == "context:" { print $2; exit }
+' "$COMPOSE_FILE")
+
+if [[ -z "$CTX" ]]; then
+    echo "ERROR: could not derive build.context from $COMPOSE_FILE" >&2
+    exit 1
+fi
+
+DEST="$LOCALNET_DIR/$CTX/story-prebuilt"
+SENTINEL="$LOCALNET_DIR/tmp/staged_binary.sha256"
+
+mkdir -p "$LOCALNET_DIR/tmp"
+cp -v "$SRC" "$DEST"
+
+HASH=$(shasum -a 256 "$DEST" | awk '{print $1}')
+BUILDID=$(file "$DEST" | grep -oE 'BuildID\[sha1\]=[a-f0-9]+' || echo 'BuildID[sha1]=<unknown>')
+
+echo "$HASH" > "$SENTINEL"
+
+echo "---"
+echo "Staged binary: $DEST"
+echo "  sha256:   $HASH"
+echo "  $BUILDID"
+echo "  sentinel: $SENTINEL  (start.sh will compare image binary against this)"

--- a/start.sh
+++ b/start.sh
@@ -15,6 +15,31 @@ if ! docker image inspect story-node:localnet >/dev/null 2>&1; then
     docker compose -f docker-compose-bootnode1.yml build bootnode1-node
 fi
 
+# Verify image binary matches the staged one (catches stale story-prebuilt /
+# wrong build context / cached image scenarios). Sentinel is written by
+# scripts/stage_binary.sh; if absent, this check is a soft warning instead
+# of a hard fail so the existing flow without staging still works.
+SENTINEL="$(pwd)/tmp/staged_binary.sha256"
+if [[ -f "$SENTINEL" ]]; then
+    EXPECTED=$(cat "$SENTINEL")
+    docker create --name verify-binary-tmp story-node:localnet >/dev/null
+    docker cp verify-binary-tmp:/usr/local/bin/story /tmp/__story_in_image >/dev/null
+    docker rm verify-binary-tmp >/dev/null
+    ACTUAL=$(shasum -a 256 /tmp/__story_in_image | awk '{print $1}')
+    rm -f /tmp/__story_in_image
+    if [[ "$EXPECTED" != "$ACTUAL" ]]; then
+        echo "❌ ERROR: image binary sha256 mismatch."
+        echo "   expected (from $SENTINEL): $EXPECTED"
+        echo "   actual   (from running image):  $ACTUAL"
+        echo "   the image was likely built from a stale story-prebuilt; rerun scripts/stage_binary.sh + force rebuild."
+        exit 1
+    fi
+    echo "✅ image binary matches staged binary (sha256 ${ACTUAL:0:16}...)"
+else
+    echo "⚠️  no $SENTINEL — skipping image-binary verification."
+    echo "    run scripts/stage_binary.sh <path-to-linux-binary> first to enable this check."
+fi
+
 # Start monitoring
 docker compose -f docker-compose-monitoring.yml up -d
 


### PR DESCRIPTION
## Summary

Two pieces of guardrail so a stale or wrong `story-prebuilt` cannot silently end up inside the docker image:

- **`scripts/stage_binary.sh`** — single canonical entry point for placing the linux story binary at the docker build-context's expected location. Derives the destination by parsing `build.context` out of `docker-compose-bootnode1.yml`, so it adapts to whichever sibling repo the context currently points at. Records sha256 of the staged binary to `tmp/staged_binary.sha256` as a sentinel.
- **`start.sh` image-binary verification** — after `docker compose build` creates the `story-node:localnet` image, extracts the binary, hashes it, and asserts equality with the sentinel. On mismatch, exits 1 before any cluster work begins. Soft warning (not failure) when no sentinel exists, preserving compatibility with workflows that don't use `stage_binary.sh`.

## Motivation

The docker-compose `build.context` for `bootnode1-node` points to a sibling repo (`../story-private-fork`) and `Dockerfile.story-node`'s `COPY story-prebuilt /usr/local/bin/story` resolves relative to that context — NOT relative to story-localnet. Manually `cp`-ing a freshly built binary to `story-localnet/story-prebuilt` is silently ignored by docker, and the cluster keeps running off whatever `story-private-fork/story-prebuilt` is. With no surface error, the cluster runs and probes pass while testing stale or wrong code.

## Usage

```bash
./scripts/stage_binary.sh <path-to-linux-story-binary>
./start.sh   # prints "image binary matches staged binary" or fails
```

## Test plan

- [x] `stage_binary.sh` parses `build.context` from compose, copies binary, writes sha256 sentinel
- [x] `start.sh` match case prints `✅ image binary matches staged binary (sha256 ...)`
- [x] `start.sh` mismatch case (corrupted sentinel) exits 1 with expected/actual sha256 diagnostic
- [x] Soft warning path when no sentinel present